### PR TITLE
Feature/Player, Loding, SceneGate, Camers

### DIFF
--- a/TeamProject/Client/Code/CCinematicCamera.cpp
+++ b/TeamProject/Client/Code/CCinematicCamera.cpp
@@ -3,9 +3,25 @@
 #include "CTransform.h"
 #include "CCamera.h"
 #include "CFactory.h"
+#include "CInputMgr.h"
 
 CCinematicCamera::CCinematicCamera(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CCameraObject(pGraphicDev)
+{
+
+}
+
+CCinematicCamera::CCinematicCamera(const CCinematicCamera& rhs)
+	: CCameraObject(rhs)
+{
+}
+
+CCinematicCamera::~CCinematicCamera()
+{
+	Free();
+}
+
+HRESULT CCinematicCamera::Ready_GameObject()
 {
 	m_pTransform = Get_Component<CTransform>();
 	m_pCamera = Get_Component<CCamera>();
@@ -29,57 +45,60 @@ CCinematicCamera::CCinematicCamera(LPDIRECT3DDEVICE9 pGraphicDev)
 
 	Set_Target(this);
 
+	CResourceMgr::Get_Instance()->Ready_Resource();
+	CResourceMgr::Get_Instance()->Load_Texture(L"UI/CinematicBar.png");
+
+	m_pBlackBarTop = CImageUIObject::Create(m_pGraphicDev);
+	m_pBlackBarTop->Set_Texture(CResourceMgr::Get_Instance()->Get_Texture(L"UI/CinematicBar.png"));
+	m_pBlackBarTop->Set_RenderSize(820, 100.f);
+	//m_pBlackBarTop->Set_Position({ -220.f, -30.f });
+	m_pBlackBarTop->Set_Position({ -220.f, -130.f});
+
+	m_pBlackBarBottom = CImageUIObject::Create(m_pGraphicDev);
+	m_pBlackBarBottom->Set_Texture(CResourceMgr::Get_Instance()->Get_Texture(L"UI/CinematicBar.png"));
+	m_pBlackBarBottom->Set_RenderSize(820, 100.f);
+	//m_pBlackBarBottom->Set_Position({ -220.f, 475 });
+	m_pBlackBarBottom->Set_Position({ -220.f, 575});
+
+	m_fbarMove = 0.f;
+	m_bCinematic = false;
+
 	CFactory::Save_Prefab(this, "CCinematicCamera");
-}
 
-CCinematicCamera::CCinematicCamera(const CCinematicCamera& rhs)
-	: CCameraObject(rhs)
-{
-}
-
-CCinematicCamera::~CCinematicCamera()
-{
-	Free();
-}
-
-HRESULT CCinematicCamera::Ready_GameObject()
-{
 	return S_OK;
 }
 
 int CCinematicCamera::Update_GameObject(const _float& fTimeDelta)
 {
-
 	if (m_bCinematic)
 	{
-		m_fTimer += fTimeDelta;
-		_float timeRatio = min(m_fTimer / m_fDuration, 1.f);
-
-		_vec3 lerpPos = m_StartPos + (m_EndPos - m_StartPos) * timeRatio;
-		m_pTransform->Set_Pos(lerpPos);
-
-		_vec3 lerpLook = m_StartLookDir + (m_EndLookDir - m_StartLookDir) * timeRatio;
-		D3DXVec3Normalize(&lerpLook, &lerpLook);
-		m_pTransform->Set_Look(lerpLook);
-
-		_float originFov = D3DX_PI * 0.25f * (timeRatio);
-		//_float lerpedFov = (1.f - timeRatio) * originFov + timeRatio * m_fCinematicFov;
-		m_pCamera->Set_Fov(originFov);
-
-		m_pCamera->Set_Eye(lerpPos);
-		m_pCamera->Set_At(lerpPos + lerpLook);
-
-		if (timeRatio >= 1.f)
-		{
-			m_bCinematic = false;
-		}
+		m_fbarMove += 100 * fTimeDelta;
+		if (m_fbarMove > 100.f)
+			m_fbarMove = 100.f;
 	}
+	else
+	{
+		m_fbarMove -= 100 * fTimeDelta;
+		if (m_fbarMove < 0.f)
+			m_fbarMove = 0.f;
+	}
+	
+	float topY = -130.f + m_fbarMove;
+	float bottomY = 575.f - m_fbarMove;
+	m_pBlackBarTop->Set_Position({ -220.f,  topY });
+	m_pBlackBarBottom->Set_Position({ -220.f,  bottomY });
 
 
+	m_pTransform->Set_Pos(m_pTargetTransform->Get_Pos());
+	m_pTransform->Set_Angle(m_pTargetTransform->Get_Angle());
+	m_pTransform->Set_Look(m_pTargetTransform->Get_Info(INFO_LOOK));
 
 	m_pCamera->AngleClamping();
 
 	CGameObject::Update_GameObject(fTimeDelta);
+
+	m_pBlackBarTop->Update_GameObject(fTimeDelta);
+	m_pBlackBarBottom->Update_GameObject(fTimeDelta);
 
 	return 0;
 }
@@ -87,36 +106,19 @@ int CCinematicCamera::Update_GameObject(const _float& fTimeDelta)
 void CCinematicCamera::LateUpdate_GameObject(const _float& fTimeDelta)
 {
 	CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+	m_pBlackBarTop->LateUpdate_GameObject(fTimeDelta);
+	m_pBlackBarBottom->LateUpdate_GameObject(fTimeDelta);
 }
 
-void CCinematicCamera::Start_Cinematic(const _vec3& startPos, const _vec3& endPos, const _vec3& endLook, _float fov, _float duration)
+void CCinematicCamera::Start_Cinematic()
 {
-	m_StartPos = startPos;
-	m_pTransform->Set_Pos(startPos);
-	m_EndPos = endPos;
-
-	_vec3 startLook = m_EndPos - m_StartPos;
-	D3DXVec3Normalize(&startLook, &startLook);
-
-	m_pTransform->Set_Look(startLook);
-	m_StartLookDir = startLook;
-	m_EndLookDir = endLook;
-
-	m_fCinematicFov = fov;
-	m_fDuration = duration;
-	m_fTimer = 0.f;
 	m_bCinematic = true;
-
-	m_pCamera->Set_Eye(m_StartPos);
-	m_pCamera->Set_At(m_StartPos + startLook);
-
-
 }
 
 void CCinematicCamera::End_Cinematic()
 {
 	m_bCinematic = false;
-	m_pCamera->Set_Fov(D3DX_PI * 0.25f);
 }
 
 void CCinematicCamera::Set_Pos(const _vec3& pos)
@@ -142,6 +144,9 @@ CCinematicCamera* CCinematicCamera::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 
 void CCinematicCamera::Free()
 {
+	Safe_Release(m_pBlackBarTop);
+	Safe_Release(m_pBlackBarBottom);
+
 	Safe_Release(m_pCamera);
 	Safe_Release(m_pTransform);
 }

--- a/TeamProject/Client/Code/CDollyCamera.cpp
+++ b/TeamProject/Client/Code/CDollyCamera.cpp
@@ -1,0 +1,168 @@
+#include "pch.h"
+#include "CDollyCamera.h"
+#include "CTransform.h"
+#include "CCamera.h"
+#include "CFactory.h"
+
+CDollyCamera::CDollyCamera(LPDIRECT3DDEVICE9 pGraphicDev)
+	: CCameraObject(pGraphicDev)
+{
+	m_pTransform = Get_Component<CTransform>();
+	m_pCamera = Get_Component<CCamera>();
+
+	m_pTransform->Set_Pos({ 0.f, 0.f, 0.f });
+	m_pTransform->Set_Angle({ 0.f, 0.f, 0.f });
+	m_pTransform->Set_Scale({ 1.f, 1.f, 1.f });
+	m_pTransform->Set_Look({ 0.f, 0.f, 1.f });
+	m_pTransform->Set_Up({ 0.f, 1.f, 0.f });
+	m_pTransform->Set_Right({ 1.f, 0.f, 0.f });
+
+	m_pCamera->Set_Eye(m_pTransform->Get_Pos());
+	m_pCamera->Set_At(m_pTransform->Get_Pos() + m_pTransform->Get_Info(INFO_LOOK));
+	m_pCamera->Set_Up(m_pTransform->Get_Info(INFO_UP));
+	m_pCamera->Set_Look(m_pTransform->Get_Info(INFO_LOOK));
+	m_pCamera->Set_Right(m_pTransform->Get_Info(INFO_RIGHT));
+	m_pCamera->Set_Fov(D3DX_PI * 0.25f);
+	m_pCamera->Set_Aspect(WINCX / (WINCY * 1.f));
+	m_pCamera->Set_Near(0.1f);
+	m_pCamera->Set_Far(1000.f);
+
+	CFactory::Save_Prefab(this, "CCinematicCamera");
+}
+
+CDollyCamera::CDollyCamera(const CDollyCamera& rhs)
+	: CCameraObject(rhs)
+{
+}
+
+CDollyCamera::~CDollyCamera()
+{
+	Free();
+}
+
+HRESULT CDollyCamera::Ready_GameObject()
+{
+	return S_OK;
+}
+
+int CDollyCamera::Update_GameObject(const _float& fTimeDelta)
+{
+	auto Lerp = [](float a, float b, float t)
+		{
+			return a + (b - a) * t;
+		};
+
+	if (m_bDolly)
+	{
+		m_fTimer += fTimeDelta;
+		_float timeRatio = min(m_fTimer / m_fDuration, 1.f);
+		timeRatio = timeRatio * timeRatio * (3.f - 2.f * timeRatio);
+
+		if (m_CurPhase == 0)
+		{
+			_vec3 lerpPos = m_StartPos + (m_MiddlePos - m_StartPos) * timeRatio;
+			m_pTransform->Set_Pos(lerpPos);
+
+			if (m_fDollyFovDelta != 0.f)
+			{
+				_float newFov = Lerp(m_OriginFov, m_OriginFov - m_fDollyFovDelta, timeRatio);
+				m_pCamera->Set_Fov(newFov);
+			}
+
+			m_pCamera->Set_Eye(lerpPos);
+			m_pCamera->Set_At(m_vTargetPos);
+
+			if (timeRatio >= 1.f)
+			{
+				m_fTimer = 0.f;
+				m_CurPhase = 1;
+			}
+		}
+		else if (m_CurPhase == 1)
+		{
+			_vec3 lerpPos = m_MiddlePos + (m_EndPos - m_MiddlePos) * timeRatio;
+			m_pTransform->Set_Pos(lerpPos);
+
+			if (m_fDollyFovDelta != 0.f)
+			{
+				_float newFov = Lerp(m_OriginFov - m_fDollyFovDelta, m_OriginFov + m_fDollyFovDelta, timeRatio);
+				m_pCamera->Set_Fov(newFov);
+			}
+
+			m_pCamera->Set_Eye(lerpPos);
+			m_pCamera->Set_At(m_vTargetPos);
+
+			if (timeRatio >= 1.f)
+			{
+				End_Dolly();
+			}
+		}
+	}
+
+	m_pCamera->AngleClamping();
+	CGameObject::Update_GameObject(fTimeDelta);
+	return 0;
+}
+
+void CDollyCamera::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+	CGameObject::LateUpdate_GameObject(fTimeDelta);
+}
+
+void CDollyCamera::Start_Dolly(CGameObject* pTarget, const _vec3& moveOffset, _float fovDelta, _float duration)
+{
+	m_pTargetTransform = pTarget->Get_Component<CTransform>();
+	m_vTargetPos = m_pTargetTransform->Get_Pos();
+
+	m_StartPos = m_pTransform->Get_Pos();
+	m_MoveOffset = moveOffset;
+
+	m_MiddlePos = m_StartPos + m_MoveOffset;
+	m_EndPos = m_StartPos;
+
+	m_CurPhase = 0;
+	m_OriginFov = D3DX_PI * 0.25f;
+	m_fDollyFovDelta = fovDelta;
+
+	m_fDuration = duration * 0.5f;
+	m_fTimer = 0.f;
+	m_bDolly = true;
+
+	m_pCamera->Set_Fov(m_OriginFov);
+}
+
+void CDollyCamera::End_Dolly()
+{
+	m_bDolly = false;
+	m_pCamera->Set_Fov(D3DX_PI * 0.25f);
+}
+
+void CDollyCamera::Set_Pos(const _vec3& pos)
+{
+	m_pTransform->Set_Pos(pos);
+}
+
+void CDollyCamera::Set_Angle(const _vec3& angle)
+{
+	m_pTransform->Set_Angle(angle);
+}
+
+CDollyCamera* CDollyCamera::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+	auto pCam = new CDollyCamera(pGraphicDev);
+	if (FAILED(pCam->Ready_GameObject()))
+	{
+		Safe_Release(pCam);
+		return nullptr;
+	}
+	return pCam;
+}
+
+void CDollyCamera::Free()
+{
+	Safe_Release(m_pCamera);
+	Safe_Release(m_pTransform);
+}
+
+REGISTER_GAMEOBJECT(CDollyCamera)
+

--- a/TeamProject/Client/Code/CMainPlayer.cpp
+++ b/TeamProject/Client/Code/CMainPlayer.cpp
@@ -170,6 +170,9 @@ void CMainPlayer::KeyInput(const _float& fTimeDelta)
 			}
 		}
 		else {
+			if (m_bObjHold)
+				m_bMouseAway = true;
+
 			m_pCrosshair->Set_State(CCrosshairUIObject::CROSSHAIR_STATE::CROSS_DEFAULT);
 			m_bObjHold = false;
 			m_vDragDistance = { 0,0,0 };

--- a/TeamProject/Client/Code/CSceneGate.cpp
+++ b/TeamProject/Client/Code/CSceneGate.cpp
@@ -50,12 +50,6 @@ HRESULT CSceneGate::Ready_GameObject()
 	//m_pTransform->Set_Scale({ 2.f, 2.f, 2.f });
 	m_pTransform->Set_Scale({ 7.f, 7.f, 7.f });
 
-	m_pTransform->Set_AngleY(25.f);
-	_matrix matRotR;
-	D3DXMatrixRotationY(&matRotR, m_pTransform->Get_Angle().y);
-	m_pTransform->Set_RotMatrix(&matRotR);
-
-
 
 
 	m_bFirstSet = true;

--- a/TeamProject/Client/Code/CSceneGate.cpp
+++ b/TeamProject/Client/Code/CSceneGate.cpp
@@ -48,7 +48,17 @@ HRESULT CSceneGate::Ready_GameObject()
 
 	m_pTransform->Set_Pos({ 0.f, -7.f, -20.f });
 	//m_pTransform->Set_Scale({ 2.f, 2.f, 2.f });
-	m_pTransform->Set_Scale({ 4.f, 4.f, 5.f });
+	m_pTransform->Set_Scale({ 7.f, 7.f, 7.f });
+
+	m_pTransform->Set_AngleY(25.f);
+	_matrix matRotR;
+	D3DXMatrixRotationY(&matRotR, m_pTransform->Get_Angle().y);
+	m_pTransform->Set_RotMatrix(&matRotR);
+
+
+
+
+	m_bFirstSet = true;
 
 	pGateDoorL = Set_GateDoor(true);
 	pGateDoorR = Set_GateDoor(false);
@@ -61,7 +71,6 @@ HRESULT CSceneGate::Ready_GameObject()
 	pGatePillarR = Set_GateStructure(vGatePos + _vec3(5.f, -2.f, -vGateScale.z - 1.f), vPillarScale);
 	const _vec3 vTopScale = { 6.f, 1.f, 2.f };
 	pGateTop = Set_GateStructure(vGatePos + _vec3(0.f, 5.f, -vGateScale.z -1.f), vTopScale);
-
 
 	pTriggerCube = CPlayerTriggerCube::Create(m_pGraphicDev);
 	pTriggerCube->Get_Component<CTransform>()->Set_Pos(vGatePos + _vec3(0.f, 0.f, -vGateScale.z - 2.f));
@@ -84,6 +93,22 @@ HRESULT CSceneGate::Ready_GameObject()
 
 int CSceneGate::Update_GameObject(const _float& fTimeDelta)
 {
+	if (m_bFirstSet)
+	{
+		Set_GateDoorPos(true, pGateDoorL);
+		Set_GateDoorPos(false, pGateDoorR);
+
+		const _vec3 vGatePos = m_pTransform->Get_Pos();
+		const _vec3 vGateScale = m_pTransform->Get_Scale();
+
+		pGatePillarL->Get_Component<CTransform>()->Set_Pos(vGatePos + _vec3(-5.f, -2.f, -vGateScale.z - 1.f));
+		pGatePillarR->Get_Component<CTransform>()->Set_Pos(vGatePos + _vec3(5.f, -2.f, -vGateScale.z - 1.f));
+		pGateTop->Get_Component<CTransform>()->Set_Pos(vGatePos + _vec3(0.f, 5.f, -vGateScale.z - 1.f));
+		pTriggerCube->Get_Component<CTransform>()->Set_Pos(vGatePos + _vec3(0.f, 0.f, -vGateScale.z - 2.f));
+
+		m_bFirstSet = false;
+	}
+
 	CGameObject::Update_GameObject(fTimeDelta);
 
 	pGateDoorL->Update_GameObject(fTimeDelta);
@@ -193,6 +218,16 @@ CTestTile* CSceneGate::Set_GateStructure(const _vec3& vPos, const _vec3& vScale)
 	pObj->Get_Component<CTransform>()->Set_Scale(vScale);
 	pObj->Get_Component<CRigidBody>()->Set_UseGravity(false);
 	return pObj;
+}
+
+void CSceneGate::Set_GateDoorPos(bool bLeft, CGameObject* pObj)
+{
+	_vec3 vGatePos = m_pTransform->Get_Info(INFO_POS);
+
+	_vec3 vOffset = { bLeft ? -4.0f : 4.0f, 0.f, -5.0f };
+	_vec3 vHingePos = vGatePos + vOffset;
+
+	pObj->Get_Component<CTransform>()->Set_Pos(vHingePos);
 }
 
 CSceneGate* CSceneGate::Create(LPDIRECT3DDEVICE9 pGraphicDev)

--- a/TeamProject/Client/Code/SceneHS.cpp
+++ b/TeamProject/Client/Code/SceneHS.cpp
@@ -69,15 +69,25 @@ HRESULT SceneHS::Ready_Scene()
 	pOnewayCube->Get_Component<CRigidBody>()->Set_OnGround(true);
 	pOnewayCube->Get_Component<CRigidBody>()->Set_UseGravity(false);
 	
+	CDirectionalCube* pDirectionalCube = CDirectionalCube::Create(m_pGraphicDev);
+	pDirectionalCube->Set_Info({ 5.f, 0.f, 0.f }, { 1.f, 0.f, 0.f }, -10.f, 10.f);
+	pDirectionalCube->Set_Grab(true);
+
+	CCrosshairUIObject* pCrosshair = CCrosshairUIObject::Create(m_pGraphicDev);
+
+	CFirstviewFollowingCamera* ffcam = CFirstviewFollowingCamera::Create(m_pGraphicDev);
+	CFirstviewFollowingCamera* dummycam = CFirstviewFollowingCamera::Create(m_pGraphicDev);
+	CCinematicCamera* pCineCam = CCinematicCamera::Create(m_pGraphicDev);
+	CDollyCamera* pDollyCam = CDollyCamera::Create(m_pGraphicDev);
+	pDollyCam->Get_Component<CTransform>()->Set_Pos(pOnewayCube->Get_Component<CTransform>()->Get_Pos());
+	pDollyCam->Start_Dolly(pOnewayCube, _vec3(0.f, 0.f, -20.f), D3DX_PI * 0.15f, 10.f);
 
 	//////////////////
 	Get_Layer(LAYER_PLAYER)->Add_GameObject(L"Player", pPlayer);
 	CSceneMgr::Get_Instance()->Set_Player(pPlayer);
 
 	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"Dummy", DummyCube::Create(m_pGraphicDev));
-	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"hwDirectionalCube", CDirectionalCube::Create(m_pGraphicDev));
-	dynamic_cast<CDirectionalCube*>(Get_Layer(LAYER_OBJECT)->Get_GameObject(L"hwDirectionalCube"))->Set_Info({ 5.f, 0.f, 0.f }, { 1.f, 0.f, 0.f }, -10.f, 10.f);
-	dynamic_cast<CDirectionalCube*>(Get_Layer(LAYER_OBJECT)->Get_GameObject(L"hwDirectionalCube"))->Set_Grab(true);
+	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"hwDirectionalCube", pDirectionalCube);
 	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"GroundDummy", (pTile));
 	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"SceneGate", CSceneGate::Create(m_pGraphicDev));
 	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"Wall", (pWall));
@@ -86,51 +96,39 @@ HRESULT SceneHS::Ready_Scene()
 	Get_Layer(LAYER_LIGHT)->Add_GameObject(L"TestLightMesh", CTestLightMeshObject::Create(m_pGraphicDev));
 	Get_Layer(LAYER_LIGHT)->Add_GameObject(L"LightObject", CLightObject::Create(m_pGraphicDev));
 	
-	Get_Layer(LAYER_UI)->Add_GameObject(L"Crosshair", CCrosshairUIObject::Create(m_pGraphicDev));
-	Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player")->Set_Crosshair(Get_Layer(LAYER_UI)->Get_GameObject<CCrosshairUIObject>(L"Crosshair"));
+	Get_Layer(LAYER_UI)->Add_GameObject(L"Crosshair", pCrosshair);
 
-	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"ffcam", CFirstviewFollowingCamera::Create(m_pGraphicDev));
-	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"dummycam", CFirstviewFollowingCamera::Create(m_pGraphicDev));
-
-	//CDollyCamera* pDollyCam = CDollyCamera::Create(m_pGraphicDev);
-	//pDollyCam->Get_Component<CTransform>()->Set_Pos(pOnewayCube->Get_Component<CTransform>()->Get_Pos());
-
-	//_vec3 endPos = Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player")->Get_Component<CTransform>()->Get_Pos();
-	//_vec3 endLook = Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player")->Get_Component<CTransform>()->Get_Info(INFO_LOOK);
-	//pDollyCam->Start_Cinematic(pOnewayCube->Get_Component<CTransform>()->Get_Pos(), {-10.f, 0.f, -20.f}, endLook, D3DX_PI * 0.15f, 5.f);
-	//pDollyCam->Start_Cinematic(pOnewayCube,30.f, -D3DX_PI * 0.1f,5.f);
-	//pDollyCam->Start_Cinematic(pOnewayCube, 150.f, -D3DX_PI * 0.25f, 10.f);
-	//
-	//Get_Layer(LAYER_CAMERA)->Add_GameObject(L"DollyCam", pDollyCam);
-
-
-	CCinematicCamera* pCineCam = CCinematicCamera::Create(m_pGraphicDev);
-	pCineCam->Set_Target(pPlayer);
-
+	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"ffcam", ffcam);
+	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"dummycam", dummycam);
+	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"DollyCam", pDollyCam);
 	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"CineCam", pCineCam);
+
 	/////////////////////
+	pCineCam->Set_Target(pPlayer);
 	Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"dummycam")->Set_Target(Get_Layer(LAYER_OBJECT)->Get_GameObject(L"Dummy"));
 	Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"ffcam")->Set_Target(Get_Layer(LAYER_PLAYER)->Get_GameObject(L"Player"));
 
-	CUiMgr::Get_Instance()->AddUI(Get_Layer(LAYER_UI)->Get_GameObject(L"Crosshair"));
 
+	pPlayer->Set_Crosshair(pCrosshair);
+	
+	CUiMgr::Get_Instance()->AddUI(Get_Layer(LAYER_UI)->Get_GameObject(L"Crosshair"));
+	
 	CCameraMgr::Get_Instance()->Set_MainCamera(Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"ffcam"));
 	//CCameraMgr::Get_Instance()->Set_MainCamera(pDollyCam);
 	//CCameraMgr::Get_Instance()->Set_MainCamera(pCineCam);
-
 
 	return S_OK;
 }
 
 _int SceneHS::Update_Scene(const _float& fTimeDelta)
 {
-	// if (CCameraMgr::Get_Instance()->Get_MainCamera() == Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam"))
-	// {
-	// 	if (!Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam")->Get_CinematicEnd())
-	// 	{
-	// 		End_Cinematic();
-	// 	}
-	// }
+	if (CCameraMgr::Get_Instance()->Get_MainCamera() == Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam"))
+	{
+		if (!Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam")->Get_DollyEnd())
+		{
+			End_Cinematic();
+		}
+	}
 
 	if (Get_Layer(LAYER_OBJECT)->Get_GameObject<CSceneGate>(L"SceneGate")->Get_InGate()) {
 		CScene* pScene = SceneBG::Create(m_pGraphicDev);
@@ -141,8 +139,6 @@ _int SceneHS::Update_Scene(const _float& fTimeDelta)
 	else {
 		CScene::Update_Scene(fTimeDelta);
 	}
-
-
 
 	// m_pLightObject->Update_GameObject(fTimeDelta);
 	// m_pTestLightMesh->Update_GameObject(fTimeDelta);
@@ -167,14 +163,13 @@ void SceneHS::LateUpdate_Scene(const _float& fTimeDelta)
 
 void SceneHS::End_Cinematic()
 {
-	Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam")->End_Cinematic();
+	Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam")->End_Dolly();
 	CCameraMgr::Get_Instance()->Set_MainCamera(Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"ffcam"));
 }
 
 SceneHS* SceneHS::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
 	SceneHS* pScene = new SceneHS(pGraphicDev);
-
 
 	if (FAILED(pScene->Ready_Scene()))
 	{
@@ -188,8 +183,5 @@ SceneHS* SceneHS::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 
 void SceneHS::Free()
 {	
-	//Clear_Layers();
 	CScene::Free();
-
-	//CRenderMgr::Get_Instance()->Clear();
 }

--- a/TeamProject/Client/Code/SceneHS.cpp
+++ b/TeamProject/Client/Code/SceneHS.cpp
@@ -23,6 +23,7 @@
 #include "CTestTile.h"
 #include "CSceneGate.h"
 #include "CCinematicCamera.h"
+#include "CDollyCamera.h"
 
 #include "SceneHW.h"
 #include "SceneBG.h"
@@ -45,7 +46,8 @@ HRESULT SceneHS::Ready_Scene()
 {
 	Init_Layers();
 
-
+	CMainPlayer* pPlayer = CMainPlayer::Create(m_pGraphicDev);
+	pPlayer->Get_Component<CTransform>()->Set_Pos({ -20.f, 20.f, -20.f });
 
 	CTestTile* pTile = CTestTile::Create(m_pGraphicDev);
 	pTile->Get_Component<CTransform>()->Set_Scale({ 50.f, 10.f, 50.f });
@@ -53,28 +55,24 @@ HRESULT SceneHS::Ready_Scene()
 	pTile->Get_Component<CRigidBody>()->Set_OnGround(true);
 	pTile->Get_Component<CRigidBody>()->Set_UseGravity(false);
 
-
 	CTestTile* pWall = CTestTile::Create(m_pGraphicDev);
 	pWall->Get_Component<CTransform>()->Set_Scale({ 50.f, 10.f, 10.f });
-	pWall->Get_Component<CTransform>()->Set_Pos({ -10.f, 0.f, 50.f });
+	pWall->Get_Component<CTransform>()->Set_Pos({ -10.f, 0.f, 100.f });
 	pWall->Get_Component<CRigidBody>()->Set_OnGround(true);
 	pWall->Get_Component<CRigidBody>()->Set_UseGravity(false);
-	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"Wall", (pWall));
-
 
 	CDirectionalCube* pOnewayCube = CDirectionalCube::Create(m_pGraphicDev);
-	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"hwOnewayCube", pOnewayCube);
 	pOnewayCube->Set_Info({ -10.f, 0.f, 30.f }, { 1.f, 0.f, 0.f }, 20.f);
 	pOnewayCube->Get_Component<CRigidBody>()->Set_Friction(0.f);
 	pOnewayCube->Get_Component<CRigidBody>()->Set_Mass(10.f);
 	pOnewayCube->Get_Component<CRigidBody>()->Set_Bounce(0.1f);
 	pOnewayCube->Get_Component<CRigidBody>()->Set_OnGround(true);
 	pOnewayCube->Get_Component<CRigidBody>()->Set_UseGravity(false);
+	
 
 	//////////////////
-	Get_Layer(LAYER_PLAYER)->Add_GameObject(L"Player", CMainPlayer::Create(m_pGraphicDev));
-	Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player")->Get_Component<CTransform>()->Set_Pos({ -20.f, 20.f, -20.f });
-	CSceneMgr::Get_Instance()->Set_Player(Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player"));
+	Get_Layer(LAYER_PLAYER)->Add_GameObject(L"Player", pPlayer);
+	CSceneMgr::Get_Instance()->Set_Player(pPlayer);
 
 	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"Dummy", DummyCube::Create(m_pGraphicDev));
 	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"hwDirectionalCube", CDirectionalCube::Create(m_pGraphicDev));
@@ -82,6 +80,8 @@ HRESULT SceneHS::Ready_Scene()
 	dynamic_cast<CDirectionalCube*>(Get_Layer(LAYER_OBJECT)->Get_GameObject(L"hwDirectionalCube"))->Set_Grab(true);
 	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"GroundDummy", (pTile));
 	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"SceneGate", CSceneGate::Create(m_pGraphicDev));
+	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"Wall", (pWall));
+	Get_Layer(LAYER_OBJECT)->Add_GameObject(L"hwOnewayCube", pOnewayCube);
 
 	Get_Layer(LAYER_LIGHT)->Add_GameObject(L"TestLightMesh", CTestLightMeshObject::Create(m_pGraphicDev));
 	Get_Layer(LAYER_LIGHT)->Add_GameObject(L"LightObject", CLightObject::Create(m_pGraphicDev));
@@ -92,40 +92,45 @@ HRESULT SceneHS::Ready_Scene()
 	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"ffcam", CFirstviewFollowingCamera::Create(m_pGraphicDev));
 	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"dummycam", CFirstviewFollowingCamera::Create(m_pGraphicDev));
 
+	//CDollyCamera* pDollyCam = CDollyCamera::Create(m_pGraphicDev);
+	//pDollyCam->Get_Component<CTransform>()->Set_Pos(pOnewayCube->Get_Component<CTransform>()->Get_Pos());
+
+	//_vec3 endPos = Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player")->Get_Component<CTransform>()->Get_Pos();
+	//_vec3 endLook = Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player")->Get_Component<CTransform>()->Get_Info(INFO_LOOK);
+	//pDollyCam->Start_Cinematic(pOnewayCube->Get_Component<CTransform>()->Get_Pos(), {-10.f, 0.f, -20.f}, endLook, D3DX_PI * 0.15f, 5.f);
+	//pDollyCam->Start_Cinematic(pOnewayCube,30.f, -D3DX_PI * 0.1f,5.f);
+	//pDollyCam->Start_Cinematic(pOnewayCube, 150.f, -D3DX_PI * 0.25f, 10.f);
+	//
+	//Get_Layer(LAYER_CAMERA)->Add_GameObject(L"DollyCam", pDollyCam);
+
+
 	CCinematicCamera* pCineCam = CCinematicCamera::Create(m_pGraphicDev);
-	pCineCam->Get_Component<CTransform>()->Set_Pos(pOnewayCube->Get_Component<CTransform>()->Get_Pos());
-	//pCineCam->Set_Eye(m_StartPos);
+	pCineCam->Set_Target(pPlayer);
 
-	_vec3 endPos = Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player")->Get_Component<CTransform>()->Get_Pos();
-	_vec3 endLook = Get_Layer(LAYER_PLAYER)->Get_GameObject<CMainPlayer>(L"Player")->Get_Component<CTransform>()->Get_Info(INFO_LOOK);
-	pCineCam->Start_Cinematic(pOnewayCube->Get_Component<CTransform>()->Get_Pos(), {-10.f, 0.f, -20.f}, endLook, D3DX_PI * 0.15f, 5.f);
-	
-	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"CinematicCam", pCineCam);
-
+	Get_Layer(LAYER_CAMERA)->Add_GameObject(L"CineCam", pCineCam);
 	/////////////////////
 	Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"dummycam")->Set_Target(Get_Layer(LAYER_OBJECT)->Get_GameObject(L"Dummy"));
 	Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"ffcam")->Set_Target(Get_Layer(LAYER_PLAYER)->Get_GameObject(L"Player"));
 
 	CUiMgr::Get_Instance()->AddUI(Get_Layer(LAYER_UI)->Get_GameObject(L"Crosshair"));
 
-	//CCameraMgr::Get_Instance()->Set_MainCamera(Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"ffcam"));
-	CCameraMgr::Get_Instance()->Set_MainCamera(Get_Layer(LAYER_CAMERA)->Get_GameObject<CCinematicCamera>(L"CinematicCam"));
+	CCameraMgr::Get_Instance()->Set_MainCamera(Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"ffcam"));
+	//CCameraMgr::Get_Instance()->Set_MainCamera(pDollyCam);
+	//CCameraMgr::Get_Instance()->Set_MainCamera(pCineCam);
 
-	for (auto& pLayer : m_umLayer)
-		pLayer.second->Ready_Layer();
 
 	return S_OK;
 }
 
 _int SceneHS::Update_Scene(const _float& fTimeDelta)
 {
-	if (CCameraMgr::Get_Instance()->Get_MainCamera() == Get_Layer(LAYER_CAMERA)->Get_GameObject<CCinematicCamera>(L"CinematicCam"))
-	{
-		if (!Get_Layer(LAYER_CAMERA)->Get_GameObject<CCinematicCamera>(L"CinematicCam")->Get_CinematicEnd())
-		{
-			End_Cinematic();
-		}
-	}
+	// if (CCameraMgr::Get_Instance()->Get_MainCamera() == Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam"))
+	// {
+	// 	if (!Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam")->Get_CinematicEnd())
+	// 	{
+	// 		End_Cinematic();
+	// 	}
+	// }
 
 	if (Get_Layer(LAYER_OBJECT)->Get_GameObject<CSceneGate>(L"SceneGate")->Get_InGate()) {
 		CScene* pScene = SceneBG::Create(m_pGraphicDev);
@@ -162,7 +167,7 @@ void SceneHS::LateUpdate_Scene(const _float& fTimeDelta)
 
 void SceneHS::End_Cinematic()
 {
-	Get_Layer(LAYER_CAMERA)->Get_GameObject<CCinematicCamera>(L"CinematicCam")->End_Cinematic();
+	Get_Layer(LAYER_CAMERA)->Get_GameObject<CDollyCamera>(L"DollyCam")->End_Cinematic();
 	CCameraMgr::Get_Instance()->Set_MainCamera(Get_Layer(LAYER_CAMERA)->Get_GameObject<CFirstviewFollowingCamera>(L"ffcam"));
 }
 

--- a/TeamProject/Client/Code/SceneLoding.cpp
+++ b/TeamProject/Client/Code/SceneLoding.cpp
@@ -73,9 +73,6 @@ HRESULT SceneLoding::Ready_Scene()
 
 	CUiMgr::Get_Instance()->AddUI(Get_Layer(LAYER_UI)->Get_GameObject(L"ProgressBar"));
 
-	for (auto& pLayer : m_umLayer)
-		pLayer.second->Ready_Layer();
-
 	return S_OK;
 }
 

--- a/TeamProject/Client/Header/CCinematicCamera.h
+++ b/TeamProject/Client/Header/CCinematicCamera.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "CCameraObject.h"
+#include "CImageUIObject.h"
 
 namespace Engine {
 	class CTransform;
@@ -21,7 +22,7 @@ public:
 	static CCinematicCamera* Create(LPDIRECT3DDEVICE9 pGraphicDev);
 	void Free();
 
-	void Start_Cinematic(const _vec3& startPos, const _vec3& endPos, const _vec3& endLook, _float fov, _float duration);
+	void Start_Cinematic();
 	void End_Cinematic();
 	
 	void Set_Target(CGameObject* target) {
@@ -38,15 +39,9 @@ private:
 	CTransform* m_pTargetTransform;
 	CCamera* m_pCamera = nullptr;
 
-	_vec3 m_StartPos;
-	_vec3 m_EndPos;
+	float m_fbarMove = 0.f;
+	bool m_bCinematic = false;
 
-	_vec3 m_StartLookDir;
-	_vec3 m_EndLookDir;
-
-	_float m_fCinematicFov = D3DX_PI * 0.15f;
-	_float m_fDuration = 0.f;
-	_float m_fTimer = 0.f;
-	bool   m_bCinematic = false;
-
+	CImageUIObject* m_pBlackBarTop = nullptr;
+	CImageUIObject* m_pBlackBarBottom = nullptr;
 };

--- a/TeamProject/Client/Header/CDollyCamera.h
+++ b/TeamProject/Client/Header/CDollyCamera.h
@@ -1,0 +1,52 @@
+#pragma once
+#include "CCameraObject.h"
+
+namespace Engine {
+	class CTransform;
+	class CCamera;
+}
+
+class CDollyCamera : public CCameraObject
+{
+private:
+	explicit CDollyCamera(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CDollyCamera(const CDollyCamera& rhs);
+	virtual ~CDollyCamera();
+
+public:
+	HRESULT Ready_GameObject() override;
+	int Update_GameObject(const _float& fTimeDelta) override;
+	void LateUpdate_GameObject(const _float& fTimeDelta) override;
+
+	static CDollyCamera* Create(LPDIRECT3DDEVICE9 pGraphicDev);
+	void Free();
+
+	void Start_Dolly(CGameObject* pTarget, const _vec3& moveOffset, _float fovDelta, _float duration);
+	void End_Dolly();
+
+	void Set_Pos(const _vec3& pos);
+	void Set_Angle(const _vec3& angle);
+
+	bool Get_DollyEnd() { return m_bDolly; }
+
+private:
+	CTransform* m_pTransform = nullptr;
+	CTransform* m_pTargetTransform;
+	CCamera* m_pCamera = nullptr;
+
+	_vec3 m_vTargetPos;
+
+	_vec3 m_StartPos;
+	_vec3 m_MiddlePos;
+	_vec3 m_EndPos;
+	_vec3 m_MoveOffset;
+
+	_float m_OriginFov = D3DX_PI * 0.25f;
+	_float m_fDollyFovDelta = 0.f;
+
+	_float m_fDuration = 0.f;
+	_float m_fTimer = 0.f;
+
+	int m_CurPhase = 0;
+	bool m_bDolly = false;
+};

--- a/TeamProject/Client/Header/CSceneGate.h
+++ b/TeamProject/Client/Header/CSceneGate.h
@@ -30,6 +30,9 @@ public:
 	CTestTile* Set_GateDoor(bool bLeft);
 	CTestTile* Set_GateStructure(const _vec3& vPos, const _vec3& vScale);
 
+
+	void Set_GateDoorPos(bool bLeft, CGameObject* pObj);
+	
 	bool Get_InGate() { return m_bInGate; };
 
 private:
@@ -52,5 +55,7 @@ private:
 	vector<CGameObject*> m_vGameObjects;
 
 	_float m_fDoorAngle = 0.f;
+
+	bool m_bFirstSet = true;
 };
 

--- a/TeamProject/Client/Include/Client.vcxproj
+++ b/TeamProject/Client/Include/Client.vcxproj
@@ -154,6 +154,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\Header\CCinematicCamera.h" />
+    <ClInclude Include="..\Header\CDollyCamera.h" />
     <ClInclude Include="..\Header\CMetalCube.h" />
     <ClInclude Include="..\Header\CImageUIObject.h" />
     <ClInclude Include="..\Header\CLodingCube.h" />
@@ -203,6 +204,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Code\CCinematicCamera.cpp" />
+    <ClCompile Include="..\Code\CDollyCamera.cpp" />
     <ClCompile Include="..\Code\CMetalCube.cpp" />
     <ClCompile Include="..\Code\CImageUIObject.cpp" />
     <ClCompile Include="..\Code\CLodingCube.cpp" />

--- a/TeamProject/Client/Include/Client.vcxproj.filters
+++ b/TeamProject/Client/Include/Client.vcxproj.filters
@@ -136,6 +136,9 @@
     <Filter Include="04. GameObjects\SceneTrigger\PlayerTriggerCube">
       <UniqueIdentifier>{c975fd68-2a60-4c8f-a3bd-9af2138f8125}</UniqueIdentifier>
     </Filter>
+    <Filter Include="04. GameObjects\CameraObejct\DollyCamera">
+      <UniqueIdentifier>{e6f3e886-84a1-46ab-b754-8e191c0e8b26}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="framework.h">
@@ -279,6 +282,9 @@
     <ClInclude Include="..\Header\CPlayerTriggerCube.h">
       <Filter>04. GameObjects\SceneTrigger\PlayerTriggerCube</Filter>
     </ClInclude>
+    <ClInclude Include="..\Header\CDollyCamera.h">
+      <Filter>04. GameObjects\CameraObejct\DollyCamera</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -412,6 +418,9 @@
     </ClCompile>
     <ClCompile Include="..\Code\CPlayerTriggerCube.cpp">
       <Filter>04. GameObjects\SceneTrigger\PlayerTriggerCube</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CDollyCamera.cpp">
+      <Filter>04. GameObjects\CameraObejct\DollyCamera</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Player, Loding, SceneGate, Camers 등 수정

### Player
---

- Player 시점 위치 변경 (FFCamer에서 수정)
- Player Mouse 클릭시 bool값 away, tap 받아올수 있게 추가


### Loding
---

- Loding 씬 배치 수정

### SceneGate
---

- SceneGate 메인 위치에 맞도록 문을 형성하는 블록들 위치 수정

### Camers
---

- CinematicCamera 추가
- CDollyCamera 추가
